### PR TITLE
environs 14.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "environs" %}
-{% set version = "14.5.0" %}
+{% set version = "14.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f7b8f6fcf3301bc674bc9c03e39b5986d116126ffb96764efd34c339ed9464ee
+  sha256: ed2767588deb503209ffe4dd9bb2b39311c2e4e7e27ce2c64bf62ca83328d068
   patches:
     - patches/0001-remove-some-django-_url-test-dependencies.patch
 
@@ -23,7 +23,7 @@ requirements:
     - flit-core <4
   run:
     - python
-    - marshmallow >=3.18.0
+    - marshmallow >=3.26.2
     - python-dotenv
     - typing-extensions  # [py<311]
 


### PR DESCRIPTION
environs 14.6.0

**Destination channel:** defaults

### Links

- [PKG-13040](https://anaconda.atlassian.net/browse/PKG-13040)
- [Upstream repository](https://github.com/sloria/environs)
- [Upstream changelog/diff](https://github.com/sloria/environs/compare/14.5.0...14.6.0)

### Explanation of changes:

- Updated environs from 14.5.0 to 14.6.0
- Bumped marshmallow dependency from >=3.18.0 to >=3.26.2 (upstream security fix for CVE-2025-68480)
- Existing patch applies cleanly
- No new dependencies or breaking changes

[PKG-13040]: https://anaconda.atlassian.net/browse/PKG-13040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ